### PR TITLE
Make IP to bind to configurable, default to 127.0.0.1 instead of all

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -59,6 +59,7 @@ function Node(config) {
     this._unloadedServices = config.services;
   }
   this.port = config.port;
+  this.ip = config.ip;
   this.https = config.https;
   this.httpsOptions = config.httpsOptions;
   this._setNetwork(config);

--- a/lib/services/web.js
+++ b/lib/services/web.js
@@ -36,6 +36,7 @@ var WebService = function(options) {
   this.https = options.https || this.node.https;
   this.httpsOptions = options.httpsOptions || this.node.httpsOptions;
   this.port = options.port || this.node.port || 3456;
+  this.ip = options.ip || this.node.ip || '127.0.0.1';
 
   // set the maximum size of json payload, defaults to express default
   // see: https://github.com/expressjs/body-parser#limit
@@ -47,7 +48,7 @@ var WebService = function(options) {
   this.node.on('ready', function() {
     self.eventNames = self.getEventNames();
     self.setupAllRoutes();
-    self.server.listen(self.port);
+    self.server.listen(self.port, self.ip);
     self.createMethodsMap();
   });
 };


### PR DESCRIPTION
Use `ip` option at same level as `port` option in `bitcore-node.json`: 

```
{
  "network": "mainnet",
  "ip": "1.2.3.4",
  "port": 3001,
  "services": [
```

besides available ipv4/ipv6 adresses, IP can be `0.0.0.0` or `::` to bind everything. Using `::` would mimic the current unchangeable behaviour. It will now default to `127.0.0.1` if unspecified.